### PR TITLE
Fixed webpack js output naming problem

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,7 +2,7 @@
 // Generated on Thu Feb 18 2016 09:04:41 GMT-0800 (PST)
 
 module.exports = function(config) {
-  var webpackConfig = require("./webpack.config.js")
+  var webpackConfig = JSON.parse(JSON.stringify(require("./webpack.config.js")));
   config.set({
 
     // base path that will be used to resolve all patterns (eg. files, exclude)


### PR DESCRIPTION
Karma is changing the webpack  config before webpack uses it to build the project. This gives karma a copy of the config so it don't change anything.